### PR TITLE
Tuxedo changed the udev rules names and so copy job fails

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,0 +1,32 @@
+on:
+  push:
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:41
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up build environment
+      run: |
+        sudo dnf install -y fedpkg fedora-packager rpmdevtools ncurses-devel pesign \
+          bpftool bc bison dwarves elfutils-devel flex gcc gcc-c++ gcc-plugin-devel \
+          glibc-static hostname m4 make net-tools openssl openssl-devel perl-devel \
+          perl-generators python3-devel which kernel-rpm-macros tree kernel-devel kmodtool \
+          && dnf clean all
+
+    - name: Set up RPM build directories
+      run: |
+        rm -rf ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS} || true
+        mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+    - name: Build modules
+      run: |
+        chmod +x build.sh
+        ./build.sh
+
+    - name: List built RPMs
+      run: |
+        tree ~/rpmbuild/RPMS/

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,7 @@
 #/bin/sh
 # Build script for Tuxedo drivers
 # Builts: tuxedo-drivers-kmod-common, kmod-tuxedo-drivers (for your kernel) and akmod-tuxedo-drivers
+set -e
 
 # Check if the kernels parameter is provided, if not, default to uname -r
 if [ -z "$1" ]; then
@@ -10,6 +11,7 @@ else
 fi
 
 echo "--> Copying spec files to ~/rpmbuild/SPECS/"
+mkdir -p ~/rpmbuild/SPECS/
 cp ./tuxedo-drivers-kmod.spec ~/rpmbuild/SPECS/
 cp ./tuxedo-drivers-kmod-common.spec ~/rpmbuild/SPECS/
 

--- a/tools/Dockerfile.build
+++ b/tools/Dockerfile.build
@@ -1,0 +1,10 @@
+FROM fedora:41
+
+RUN dnf update -y && dnf clean all
+
+RUN dnf install -y fedpkg fedora-packager rpmdevtools ncurses-devel pesign \
+    bpftool bc bison dwarves elfutils-devel flex gcc gcc-c++ gcc-plugin-devel \
+    glibc-static hostname m4 make net-tools openssl openssl-devel perl-devel \
+    perl-generators python3-devel which kernel-rpm-macros tree kernel-devel kmodtool \
+    && dnf clean all
+

--- a/tools/build_in_container.sh
+++ b/tools/build_in_container.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+
+docker build -t tuxedo-drivers-builder . -f Dockerfile.build
+
+docker run -it -v "$PWD":/build tuxedo-drivers-builder /build/tools/build.sh "$@"

--- a/tuxedo-drivers-kmod-common.spec
+++ b/tuxedo-drivers-kmod-common.spec
@@ -6,7 +6,7 @@
 %global module_names tuxedo_compatibility_check tuxedo_keyboard clevo_acpi clevo_wmi uniwill_wmi tuxedo_io tuxedo_nb02_nvidia_power_ctrl ite_8291 ite_8291_lb ite_8297 ite_829x tuxedo_nb05_ec tuxedo_nb05_power_profiles tuxedo_nb05_sensors tuxedo_nb05_keyboard tuxedo_nb05_kbd_backlight tuxedo_nb05_fan_control tuxedo_nb04_keyboard tuxedo_nb04_wmi_ab tuxedo_nb04_wmi_bs tuxedo_nb04_sensors tuxedo_nb04_power_profiles tuxedo_nb04_kbd_backlight stk8321 gxtp7380 tuxedo_tuxi_fan_control tuxi_acpi
 
 Name:     %{short}-kmod-common
-Version:  4.14.1
+Version:  4.14.2
 Release:  1%{?dist}
 Summary:  Tuxedo drivers kmod common files
 License:  GPL-2.0-or-later

--- a/tuxedo-drivers-kmod.spec
+++ b/tuxedo-drivers-kmod.spec
@@ -4,7 +4,7 @@
 %endif
 
 Name:     tuxedo-drivers-kmod
-Version:  4.14.1
+Version:  4.14.2
 Release:  1%{?dist}
 Summary:  Tuxedo drivers as kmod
 License:  GPL-2.0-or-later

--- a/tuxedo-drivers-kmod.spec
+++ b/tuxedo-drivers-kmod.spec
@@ -55,19 +55,23 @@ cp tuxedo_keyboard.conf %{buildroot}/%{_sysconfdir}/modprobe.d/tuxedo_keyboard.c
 
 # Copy udev rules
 mkdir -p %{buildroot}/usr/lib/udev/rules.d/
-cp 99-z-tuxedo-systemd-fix.rules %{buildroot}/usr/lib/udev/rules.d/
-cp 99-infinityflex-touchpanel-toggle.rules %{buildroot}/usr/lib/udev/rules.d/
+cp 99-tuxedo-fix-infinity-flex-touchpanel-toggle.rules %{buildroot}/usr/lib/udev/rules.d/
+cp 99-tuxedo-fix-nb02-touchpad-mouse.rules %{buildroot}/usr/lib/udev/rules.d/
+cp 99-tuxedo-fix-systemd-led-bootdelay.rules %{buildroot}/usr/lib/udev/rules.d/
 
 # Copy udev hwdb
 mkdir -p %{buildroot}/usr/lib/udev/hwdb.d/
-cp 61-sensor-infinityflex.hwdb %{buildroot}/usr/lib/udev/hwdb.d/
+cp 61-keyboard-tuxedo.hwdb %{buildroot}/usr/lib/udev/hwdb.d/
+cp 61-sensor-tuxedo.hwdb %{buildroot}/usr/lib/udev/hwdb.d/
 
 %{?akmod_install}
 
 %files
-/usr/lib/udev/rules.d/99-z-tuxedo-systemd-fix.rules
-/usr/lib/udev/rules.d/99-infinityflex-touchpanel-toggle.rules
-/usr/lib/udev/hwdb.d/61-sensor-infinityflex.hwdb
+/usr/lib/udev/rules.d/99-tuxedo-fix-infinity-flex-touchpanel-toggle.rules
+/usr/lib/udev/rules.d/99-tuxedo-fix-nb02-touchpad-mouse.rules
+/usr/lib/udev/rules.d/99-tuxedo-fix-systemd-led-bootdelay.rules
+/usr/lib/udev/hwdb.d/61-sensor-tuxedo.hwdb
+/usr/lib/udev/hwdb.d/61-keyboard-tuxedo.hwdb
 %doc README.md
 %license debian/copyright
 

--- a/tuxedo-drivers-kmod.spec
+++ b/tuxedo-drivers-kmod.spec
@@ -55,19 +55,23 @@ cp tuxedo_keyboard.conf %{buildroot}/%{_sysconfdir}/modprobe.d/tuxedo_keyboard.c
 
 # Copy udev rules
 mkdir -p %{buildroot}/usr/lib/udev/rules.d/
-cp 99-z-tuxedo-systemd-fix.rules %{buildroot}/usr/lib/udev/rules.d/
-cp 99-infinityflex-touchpanel-toggle.rules %{buildroot}/usr/lib/udev/rules.d/
+cp 99-tuxedo-fix-systemd-led-bootdelay.rules %{buildroot}/usr/lib/udev/rules.d/
+cp 99-tuxedo-fix-infinity-flex-touchpanel-toggle.rules %{buildroot}/usr/lib/udev/rules.d/
+cp 99-tuxedo-fix-nb02-touchpad-mouse.rules %{buildroot}/usr/lib/udev/rules.d/
 
 # Copy udev hwdb
 mkdir -p %{buildroot}/usr/lib/udev/hwdb.d/
-cp 61-sensor-infinityflex.hwdb %{buildroot}/usr/lib/udev/hwdb.d/
+cp 61-sensor-tuxedo.hwdb %{buildroot}/usr/lib/udev/hwdb.d/
+cp 61-keyboard-tuxedo.hwdb %{buildroot}/usr/lib/udev/hwdb.d/
 
 %{?akmod_install}
 
 %files
-/usr/lib/udev/rules.d/99-z-tuxedo-systemd-fix.rules
-/usr/lib/udev/rules.d/99-infinityflex-touchpanel-toggle.rules
-/usr/lib/udev/hwdb.d/61-sensor-infinityflex.hwdb
+/usr/lib/udev/rules.d/99-tuxedo-fix-systemd-led-bootdelay.rules
+/usr/lib/udev/rules.d/99-tuxedo-fix-infinity-flex-touchpanel-toggle.rules
+/usr/lib/udev/rules.d/99-tuxedo-fix-nb02-touchpad-mouse.rules
+/usr/lib/udev/hwdb.d/61-sensor-tuxedo.hwdb
+/usr/lib/udev/hwdb.d/61-keyboard-tuxedo.hwdb
 %doc README.md
 %license debian/copyright
 


### PR DESCRIPTION
udev rules in tuxedo repository changed name some weeks ago, so this can't build anymore.

I updated the version to 4.14.2 and added the new rules.